### PR TITLE
Replace hardcoded /tmp paths with tempdir in tests

### DIFF
--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -177,7 +177,7 @@ def create_fake_registry(base_dir: Path) -> Any:
 def create_fake_proc_entry(
     pid: int = 1234,
     command: list[str] | None = None,
-    working_directory: str = "/tmp",
+    working_directory: str | None = None,
     status: str = "running",
     label: str = "test-process",
     proc: Any = None,
@@ -186,6 +186,11 @@ def create_fake_proc_entry(
     """Create a fake process entry for testing."""
     if command is None:
         command = ["echo", "hello"]
+
+    if working_directory is None:
+        import tempfile
+
+        working_directory = tempfile.gettempdir()
 
     if log_prefix is None:
         log_prefix = f"{pid}.echo"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,16 +117,16 @@ def test_parse_cli_restart_process_by_command(mock_setup_logging):
     assert action.args.args == ["10"]
 
 
-def test_parse_cli_restart_process_by_command_and_cwd(mock_setup_logging):
+def test_parse_cli_restart_process_by_command_and_cwd(mock_setup_logging, tmp_path):
     """Test `persistproc restart sleep 10 --working-directory /tmp`."""
     action, metadata = parse_cli(
-        ["restart", "--working-directory", "/tmp", "sleep", "10"]
+        ["restart", "--working-directory", str(tmp_path), "sleep", "10"]
     )
     assert isinstance(action, ToolAction)
     assert action.tool.name == "restart"
     assert action.args.target == "sleep"
     assert action.args.args == ["10"]
-    assert action.args.working_directory == "/tmp"
+    assert action.args.working_directory == str(tmp_path)
 
 
 def test_parse_cli_data_dir_and_verbose_for_logging(mock_setup_logging):

--- a/tests/test_text_formatters.py
+++ b/tests/test_text_formatters.py
@@ -70,12 +70,12 @@ class TestStopProcessResultFormatter:
 
 
 class TestListProcessesResultFormatter:
-    def test_format_multiple_processes(self):
+    def test_format_multiple_processes(self, tmp_path):
         processes = [
             ProcessInfo(
                 pid=1234,
                 command=["python", "script1.py"],
-                working_directory="/tmp",
+                working_directory=str(tmp_path),
                 status="running",
                 label="process 1",
             ),
@@ -92,7 +92,7 @@ class TestListProcessesResultFormatter:
 
         assert "PID 1234: process 1 (running)" in formatted
         assert "Command: python script1.py" in formatted
-        assert "Working directory: /tmp" in formatted
+        assert f"Working directory: {tmp_path}" in formatted
         assert "PID 5678: process 2 (stopped)" in formatted
         assert "Command: node server.js" in formatted
         assert "Working directory: /app" in formatted
@@ -102,12 +102,12 @@ class TestListProcessesResultFormatter:
         formatted = format_list_processes_result(result)
         assert formatted == "No processes running"
 
-    def test_format_single_process(self):
+    def test_format_single_process(self, tmp_path):
         processes = [
             ProcessInfo(
                 pid=1234,
                 command=["python", "script.py"],
-                working_directory="/tmp",
+                working_directory=str(tmp_path),
                 status="running",
                 label="test process",
             )
@@ -117,7 +117,7 @@ class TestListProcessesResultFormatter:
 
         assert "PID 1234: test process (running)" in formatted
         assert "Command: python script.py" in formatted
-        assert "Working directory: /tmp" in formatted
+        assert f"Working directory: {tmp_path}" in formatted
         # Should not end with empty line for single process
         assert not formatted.endswith("\n\n")
 


### PR DESCRIPTION
- Update test_text_formatters.py to use tmp_path fixture
- Update test_process_manager_unit.py to use tmp_path instead of /tmp
- Update test_cli.py to use tmp_path for working directory tests
- Update test_tools_unit.py to use tmp_path fixture throughout
- Update fakes.py to use tempfile.gettempdir() as fallback

Improves test isolation and cross-platform compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)