### PR TITLE
Replace start/stop/restart with 'ctrl'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## Unreleased
 
+## 0.2.0 - 2025-01-08
+
+### Added
+- New unified `ctrl` tool that consolidates start, stop, and restart operations into a single MCP tool
+    - `persistproc start`, `persistproc stop`, and `persistproc restart` commands continue to work as aliases
+- Support for `--environment` flag in start operations for setting environment variables via JSON
+
 ## 0.1.0 - 2025-07-06
 
 - Initial release of persistproc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,7 @@ Web links supporting my changes:
 
 I solemnly swear there are no further steps I can take to verify the changes within the boundaries set for me.
 </ReportFormat>
+
+## Pitfalls
+
+persistproc/run.py has soft, non-type-safe dependencies on other parts of the program. Audit it carefully, especially after changes to persistproc/tools.py.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A shared process layer for multi-agent development workflows
 
 ## What is `persistproc`?
 
-Persistproc is an MCP server which lets agents and humans see and control long-running processes like web servers. The goal is to reduce the amount of copying and pasting you need to do, make it easier for you to use multiple agents, and be tool-agnostic.
+Persistproc is an MCP server and command line tool which lets agents and humans see and control long-running processes like web servers. The goal is to reduce the amount of copying and pasting you need to do while coding with AI, make it easier for you to use multiple agents, and be tool-agnostic.
 
 There is no config file. Processes are managed entirely at runtime. This is not a replacement for supervisord.
 
@@ -96,7 +96,7 @@ The server exposes the following tools:
 
 | Tool | Description |
 | --- | --- |
-| **ctrl** | **Unified process control: start, stop, or restart processes with a single command.** |
+| ctrl | Unified process control: start, stop, or restart processes. |
 | list | List all managed processes and their status. Can optionally filter by pid, command, or working directory and provides log paths. |
 | output | Retrieve captured output from a process. |
 | kill_persistproc | Kill all managed processes and get the PID of the persistproc server. |

--- a/README.md
+++ b/README.md
@@ -97,10 +97,7 @@ The server exposes the following tools:
 | Tool | Description |
 | --- | --- |
 | **ctrl** | **Unified process control: start, stop, or restart processes with a single command.** |
-| start | Start a new long-running process. |
 | list | List all managed processes and their status. Can optionally filter by pid, command, or working directory and provides log paths. |
-| stop | Stop a running process. |
-| restart | Stops a process and starts it again with the same parameters. |
 | output | Retrieve captured output from a process. |
 | kill_persistproc | Kill all managed processes and get the PID of the persistproc server. |
 
@@ -148,7 +145,7 @@ Once your agent is connected, you can ask it to manage your processes. Assuming 
     *   **Agent**: Calls `list()` and shows you the running `npm run dev` process.
 
 *   **You**: "The web server seems stuck. Can you restart it?"
-    *   **Agent**: Identifies the correct process and calls `restart(pid=12345)`.
+    *   **Agent**: Identifies the correct process and calls `ctrl(action="restart", pid=12345)`.
 
 *   **You**: "Show me any errors from the web server."
     *   **Agent**: Calls `output(pid=12345, stream="stderr")` to retrieve the latest error logs.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The server exposes the following tools:
 
 | Tool | Description |
 | --- | --- |
+| **ctrl** | **Unified process control: start, stop, or restart processes with a single command.** |
 | start | Start a new long-running process. |
 | list | List all managed processes and their status. Can optionally filter by pid, command, or working directory and provides log paths. |
 | stop | Stop a running process. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,7 @@ The server exposes the following tools:
 
 | Tool | Description |
 | --- | --- |
+| **ctrl** | **Unified process control: start, stop, or restart processes with a single command.** |
 | start | Start a new long-running process. |
 | list | List all managed processes and their status. Can optionally filter by pid, command, or working directory and provides log paths. |
 | stop | Stop a running process. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ A shared process layer for multi-agent development workflows
 
 ## What is `persistproc`?
 
-Persistproc is an MCP server which lets agents and humans see and control long-running processes like web servers. The goal is to reduce the amount of copying and pasting you need to do, make it easier for you to use multiple agents, and be tool-agnostic.
+Persistproc is an MCP server and command line tool which lets agents and humans see and control long-running processes like web servers. The goal is to reduce the amount of copying and pasting you need to do while coding with AI, make it easier for you to use multiple agents, and be tool-agnostic.
 
 There is no config file. Processes are managed entirely at runtime. This is not a replacement for supervisord.
 
@@ -95,11 +95,8 @@ The server exposes the following tools:
 
 | Tool | Description |
 | --- | --- |
-| **ctrl** | **Unified process control: start, stop, or restart processes with a single command.** |
-| start | Start a new long-running process. |
+| ctrl | Unified process control: start, stop, or restart processes. |
 | list | List all managed processes and their status. Can optionally filter by pid, command, or working directory and provides log paths. |
-| stop | Stop a running process. |
-| restart | Stops a process and starts it again with the same parameters. |
 | output | Retrieve captured output from a process. |
 | kill_persistproc | Kill all managed processes and get the PID of the persistproc server. |
 
@@ -147,7 +144,7 @@ Once your agent is connected, you can ask it to manage your processes. Assuming 
     *   **Agent**: Calls `list()` and shows you the running `npm run dev` process.
 
 *   **You**: "The web server seems stuck. Can you restart it?"
-    *   **Agent**: Identifies the correct process and calls `restart(pid=12345)`.
+    *   **Agent**: Identifies the correct process and calls `ctrl(action="restart", pid=12345)`.
 
 *   **You**: "Show me any errors from the web server."
     *   **Agent**: Calls `output(pid=12345, stream="stderr")` to retrieve the latest error logs.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,120 +1,6 @@
-# Tools and commands
+# Command line usage
 
-This page documents all persistproc commands and their usage. Most commands are available both from the command line and as MCP tools for agents, with a few exceptions noted below.
-
-!!! info "What is a tool?"
-    persistproc is primarily an MCP server, but all its tools are accessible to you on the command line. This page will discuss each tool in its command line form. The agent has access to the exact same functionality, just through a different mechanism for calling the tools.
-
-## `ctrl`
-
-**Unified process control** - the recommended way to manage processes with persistproc. This command provides a single interface for start, stop, and restart operations with consistent arguments and output format.
-
-<!-- persistproc ctrl --help -->
-```
-usage: persistproc ctrl [-h] [--port PORT] [--data-dir DATA_DIR] [-v] [-q]
-                        [--format {text,json}] [--working-directory WORKING_DIRECTORY]
-                        [--environment ENVIRONMENT] [--force] [--label LABEL]
-                        {start,stop,restart} TARGET [args ...]
-
-positional arguments:
-  {start,stop,restart}  The action to perform: start, stop, or restart
-  TARGET                The PID, label, command, or command to start (depending on action)
-  args                  Arguments to the command
-
-options:
-  -h, --help            show this help message and exit
-  --port PORT           Server port (default: 8947; env: $PERSISTPROC_PORT)
-  --data-dir DATA_DIR   Data directory (default:
-                        ~/Library/Application Support/persistproc;
-                        env: $PERSISTPROC_DATA_DIR)
-  -v, --verbose         Increase verbosity; you can use -vv for more
-  -q, --quiet           Decrease verbosity. Passing -q once will show only
-                        warnings and errors.
-  --format {text,json}  Output format (default: text; env:
-                        $PERSISTPROC_FORMAT)
-  --working-directory WORKING_DIRECTORY
-                        The working directory for the process (required for start, optional for stop/restart)
-  --environment ENVIRONMENT
-                        Environment variables as JSON string (start only)
-  --force               Force stop the process (stop only)
-  --label LABEL         Custom label for the process
-```
-
-**Examples**
-
-Start a new process:
-
-```bash
-> persistproc ctrl start npm run dev
-Started process with PID: 12345
-Action: start
-Label: npm run dev in /Users/user/myproject
-Stdout log: /Users/user/Library/Application Support/persistproc/logs/12345_stdout.log
-Stderr log: /Users/user/Library/Application Support/persistproc/logs/12345_stderr.log
-Combined log: /Users/user/Library/Application Support/persistproc/logs/12345_combined.log
-```
-
-Start with custom working directory and label:
-
-```bash
-> persistproc ctrl --working-directory /path/to/project --label "api-server" start python -m uvicorn app:main --host 0.0.0.0 --port 8000
-```
-
-Start with environment variables:
-
-```bash
-> persistproc ctrl --environment '{"DEBUG": "1", "PORT": "3000"}' start node server.js
-```
-
-Stop a process by PID:
-
-```bash
-> persistproc ctrl stop 12345
-Action: stop
-PID: 12345
-Previous exit code: 0
-Stdout log: /Users/user/Library/Application Support/persistproc/logs/12345_stdout.log
-Stderr log: /Users/user/Library/Application Support/persistproc/logs/12345_stderr.log
-Combined log: /Users/user/Library/Application Support/persistproc/logs/12345_combined.log
-```
-
-Stop a process by command:
-
-```bash
-> persistproc ctrl stop npm run dev
-> persistproc ctrl --working-directory /path/to/project stop npm run dev
-```
-
-Force stop a process:
-
-```bash
-> persistproc ctrl --force stop 12345
-```
-
-Restart a process:
-
-```bash
-> persistproc ctrl restart 12345
-Action: restart
-PID: 54321
-Previous exit code: 0
-Stdout log: /Users/user/Library/Application Support/persistproc/logs/54321_stdout.log
-Stderr log: /Users/user/Library/Application Support/persistproc/logs/54321_stderr.log
-Combined log: /Users/user/Library/Application Support/persistproc/logs/54321_combined.log
-
-> persistproc ctrl restart npm run dev
-> persistproc ctrl --working-directory /path/to/project restart "my-server-label"
-```
-
-!!! tip "Why use ctrl?"
-    The `ctrl` command provides several advantages over individual commands:
-    
-    - **Unified interface**: One command with consistent options for all operations
-    - **Enhanced output**: Always includes log paths in results for easy access
-    - **Better semantics**: Clear action-based syntax that's easy to understand
-    - **Future-proof**: New features will be added to ctrl first
-    
-    While the individual `start`, `stop`, and `restart` commands remain available for backwards compatibility, `ctrl` is recommended for new workflows.
+This page documents all persistproc commands and their usage.
 
 ## `serve`
 
@@ -256,11 +142,11 @@ Start a new process.
 usage: persistproc start [-h] [--port PORT] [--data-dir DATA_DIR] [-v] [-q]
                          [--format {text,json}]
                          [--working-directory WORKING_DIRECTORY]
-                         [--label LABEL]
+                         [--environment ENVIRONMENT] [--label LABEL]
                          COMMAND [args ...]
 
 positional arguments:
-  COMMAND               The command to run.
+  COMMAND               The command to start
   args                  Arguments to the command
 
 options:
@@ -275,9 +161,10 @@ options:
   --format {text,json}  Output format (default: text; env:
                         $PERSISTPROC_FORMAT)
   --working-directory WORKING_DIRECTORY
-                        The working directory for the process.
-  --label LABEL         Custom label for the process (default: '<command> in
-                        <working_directory>').
+                        The working directory for the process
+  --environment ENVIRONMENT
+                        Environment variables as JSON string
+  --label LABEL         Custom label for the process
 ```
 
 **Examples**
@@ -295,12 +182,6 @@ Combined log: /Users/user/Library/Application Support/persistproc/logs/12345_com
 
 ```bash
 > persistproc start python -m http.server 8080
-```
-
-Unlike `run`, the `start` command doesn't stream output, so you typically don't need `--` for flag conflicts:
-
-```bash
-> persistproc start echo -v "verbose output"
 ```
 
 Specify a working directory:
@@ -321,6 +202,120 @@ Add a custom label for complex commands:
 ```bash
 > persistproc start --label "worker-pool" 'celery -A myapp worker --loglevel=info --concurrency=4 --queues=high_priority,low_priority'
 ```
+
+
+## `stop`
+
+Stop a running process.
+
+<!-- persistproc stop --help -->
+```
+usage: persistproc stop [-h] [--port PORT] [--data-dir DATA_DIR] [-v] [-q]
+                        [--format {text,json}]
+                        [--working-directory WORKING_DIRECTORY] [--force]
+                        TARGET [args ...]
+
+positional arguments:
+  TARGET                The PID, label, or command to stop/restart
+  args                  Arguments to the command
+
+options:
+  -h, --help            show this help message and exit
+  --port PORT           Server port (default: 8947; env: $PERSISTPROC_PORT)
+  --data-dir DATA_DIR   Data directory (default:
+                        ~/Library/Application Support/persistproc;
+                        env: $PERSISTPROC_DATA_DIR)
+  -v, --verbose         Increase verbosity; you can use -vv for more
+  -q, --quiet           Decrease verbosity. Passing -q once will show only
+                        warnings and errors.
+  --format {text,json}  Output format (default: text; env:
+                        $PERSISTPROC_FORMAT)
+  --working-directory WORKING_DIRECTORY
+                        The working directory for the process
+  --force               Force stop the process
+```
+
+**Examples**
+
+Stop a process by PID, command, or label:
+
+```bash
+> persistproc stop 12345
+Process stopped with exit code: 0
+
+> persistproc stop npm run dev
+> persistproc stop "my-dev-server"
+```
+
+Add working directory context when matching by command:
+
+```bash
+> persistproc stop --working-directory /path/to/project npm run dev
+```
+
+Force stop if the process doesn't respond to normal termination:
+
+```bash
+> persistproc stop --force 12345
+```
+
+
+## `restart`
+
+Stops a process and starts it again with the same arguments and working directory.
+
+First, the process shuts down completely. If the process fails to shut down within the timeout period, returns an error.
+
+Then, the command, working directory, and environment variables are reused to start a fresh copy of the process.
+
+`output` will only return the logs for the latest copy of the process, not the history of every run.
+
+<!-- persistproc restart --help -->
+```
+usage: persistproc restart [-h] [--port PORT] [--data-dir DATA_DIR] [-v] [-q]
+                           [--format {text,json}]
+                           [--working-directory WORKING_DIRECTORY]
+                           [--label LABEL]
+                           TARGET [args ...]
+
+positional arguments:
+  TARGET                The PID, label, or command to stop/restart
+  args                  Arguments to the command
+
+options:
+  -h, --help            show this help message and exit
+  --port PORT           Server port (default: 8947; env: $PERSISTPROC_PORT)
+  --data-dir DATA_DIR   Data directory (default:
+                        ~/Library/Application Support/persistproc;
+                        env: $PERSISTPROC_DATA_DIR)
+  -v, --verbose         Increase verbosity; you can use -vv for more
+  -q, --quiet           Decrease verbosity. Passing -q once will show only
+                        warnings and errors.
+  --format {text,json}  Output format (default: text; env:
+                        $PERSISTPROC_FORMAT)
+  --working-directory WORKING_DIRECTORY
+                        The working directory for the process
+  --label LABEL         Custom label for the process
+```
+
+**Examples**
+
+Restart a process by PID, command, or label:
+
+```bash
+> persistproc restart 12345
+Process restarted with PID: 54321
+
+> persistproc restart npm run dev
+> persistproc restart "my-dev-server"
+```
+
+Add working directory context when matching by command:
+
+```bash
+> persistproc restart --working-directory /path/to/project npm run dev
+```
+
 
 ## `list`
 
@@ -395,114 +390,6 @@ Get more detailed output or different formats:
 > persistproc list --format json
 ```
 
-## `stop`
-
-Stop a running process.
-
-<!-- persistproc stop --help -->
-```
-usage: persistproc stop [-h] [--port PORT] [--data-dir DATA_DIR] [-v] [-q]
-                        [--format {text,json}]
-                        [--working-directory WORKING_DIRECTORY] [--force]
-                        TARGET [args ...]
-
-positional arguments:
-  TARGET                The PID, label, or command to stop.
-  args                  Arguments to the command
-
-options:
-  -h, --help            show this help message and exit
-  --port PORT           Server port (default: 8947; env: $PERSISTPROC_PORT)
-  --data-dir DATA_DIR   Data directory (default:
-                        ~/Library/Application Support/persistproc;
-                        env: $PERSISTPROC_DATA_DIR)
-  -v, --verbose         Increase verbosity; you can use -vv for more
-  -q, --quiet           Decrease verbosity. Passing -q once will show only
-                        warnings and errors.
-  --format {text,json}  Output format (default: text; env:
-                        $PERSISTPROC_FORMAT)
-  --working-directory WORKING_DIRECTORY
-                        The working directory for the process.
-  --force               Force stop the process.
-```
-
-**Examples**
-
-Stop a process by PID, command, or label:
-
-```bash
-> persistproc stop 12345
-Process stopped with exit code: 0
-
-> persistproc stop npm run dev
-> persistproc stop "my-dev-server"
-```
-
-Add working directory context when matching by command:
-
-```bash
-> persistproc stop --working-directory /path/to/project npm run dev
-```
-
-Force stop if the process doesn't respond to normal termination:
-
-```bash
-> persistproc stop --force 12345
-```
-
-## `restart`
-
-Stops a process and starts it again with the same arguments and working directory.
-
-First, the process shut down completely. If the process fails to shut down within xxx, returns an error. TODO cross reference with 'stop'
-
-Then, the command, working directory, and environment variables are reused to start a fresh copy of the process.
-
-`output` will only return the logs for the latest copy of the process, not the history of every run.
-
-<!-- persistproc restart --help -->
-```
-usage: persistproc restart [-h] [--port PORT] [--data-dir DATA_DIR] [-v] [-q]
-                           [--format {text,json}]
-                           [--working-directory WORKING_DIRECTORY]
-                           TARGET [args ...]
-
-positional arguments:
-  TARGET                The PID, label, or command to restart.
-  args
-
-options:
-  -h, --help            show this help message and exit
-  --port PORT           Server port (default: 8947; env: $PERSISTPROC_PORT)
-  --data-dir DATA_DIR   Data directory (default:
-                        ~/Library/Application Support/persistproc;
-                        env: $PERSISTPROC_DATA_DIR)
-  -v, --verbose         Increase verbosity; you can use -vv for more
-  -q, --quiet           Decrease verbosity. Passing -q once will show only
-                        warnings and errors.
-  --format {text,json}  Output format (default: text; env:
-                        $PERSISTPROC_FORMAT)
-  --working-directory WORKING_DIRECTORY
-                        The working directory for the process.
-```
-
-**Examples**
-
-Restart a process by PID, command, or label:
-
-```bash
-> persistproc restart 12345
-Process restarted with PID: 54321
-
-> persistproc restart npm run dev
-> persistproc restart "my-dev-server"
-```
-
-Add working directory context when matching by command:
-
-```bash
-> persistproc restart --working-directory /path/to/project npm run dev
-```
 
 ## `output`
 
@@ -624,4 +511,108 @@ Get structured output showing the server PID:
 
 ```bash
 > persistproc kill_persistproc --format json
+```
+
+## `ctrl`
+
+`start`, `stop`, and `restart` are aliases for `ctrl start`, `ctrl stop`, and `ctrl restart`. The MCP server provides a single `ctrl` tool to minimize the number of tools it exposes, and tools are automatically mapped to commands, so `ctrl` itself is available as a command.
+
+<!-- persistproc ctrl --help -->
+```
+usage: persistproc ctrl [-h] [--port PORT] [--data-dir DATA_DIR] [-v] [-q]
+                        [--format {text,json}]
+                        [--working-directory WORKING_DIRECTORY]
+                        [--environment ENVIRONMENT] [--force] [--label LABEL]
+                        {start,stop,restart} TARGET [args ...]
+
+positional arguments:
+  {start,stop,restart}  The action to perform: start, stop, or restart
+  TARGET                The PID, label, command, or command to start
+                        (depending on action)
+  args                  Arguments to the command
+
+options:
+  -h, --help            show this help message and exit
+  --port PORT           Server port (default: 8947; env: $PERSISTPROC_PORT)
+  --data-dir DATA_DIR   Data directory (default:
+                        ~/Library/Application Support/persistproc;
+                        env: $PERSISTPROC_DATA_DIR)
+  -v, --verbose         Increase verbosity; you can use -vv for more
+  -q, --quiet           Decrease verbosity. Passing -q once will show only
+                        warnings and errors.
+  --format {text,json}  Output format (default: text; env:
+                        $PERSISTPROC_FORMAT)
+  --working-directory WORKING_DIRECTORY
+                        The working directory for the process (required for
+                        start, optional for stop/restart)
+  --environment ENVIRONMENT
+                        Environment variables as JSON string (start only)
+  --force               Force stop the process (stop only)
+  --label LABEL         Custom label for the process
+```
+
+**Examples**
+
+Start a new process (equivalent to `persistproc start`):
+
+```bash
+> persistproc ctrl start npm run dev
+Started process with PID: 12345
+Action: start
+Label: npm run dev in /Users/user/myproject
+Stdout log: /Users/user/Library/Application Support/persistproc/logs/12345_stdout.log
+Stderr log: /Users/user/Library/Application Support/persistproc/logs/12345_stderr.log
+Combined log: /Users/user/Library/Application Support/persistproc/logs/12345_combined.log
+```
+
+Start with custom working directory and label:
+
+```bash
+> persistproc ctrl --working-directory /path/to/project --label "api-server" start python -m uvicorn app:main --host 0.0.0.0 --port 8000
+```
+
+Start with environment variables:
+
+```bash
+> persistproc ctrl --environment '{"DEBUG": "1", "PORT": "3000"}' start node server.js
+```
+
+Stop a process by PID (equivalent to `persistproc stop`):
+
+```bash
+> persistproc ctrl stop 12345
+Action: stop
+PID: 12345
+Exit code: 0
+Stdout log: /Users/user/Library/Application Support/persistproc/logs/12345_stdout.log
+Stderr log: /Users/user/Library/Application Support/persistproc/logs/12345_stderr.log
+Combined log: /Users/user/Library/Application Support/persistproc/logs/12345_combined.log
+```
+
+Stop a process by command:
+
+```bash
+> persistproc ctrl stop npm run dev
+> persistproc ctrl --working-directory /path/to/project stop npm run dev
+```
+
+Force stop a process:
+
+```bash
+> persistproc ctrl --force stop 12345
+```
+
+Restart a process (equivalent to `persistproc restart`):
+
+```bash
+> persistproc ctrl restart 12345
+Action: restart
+PID: 54321
+Exit code: 0
+Stdout log: /Users/user/Library/Application Support/persistproc/logs/54321_stdout.log
+Stderr log: /Users/user/Library/Application Support/persistproc/logs/54321_stderr.log
+Combined log: /Users/user/Library/Application Support/persistproc/logs/54321_combined.log
+
+> persistproc ctrl restart npm run dev
+> persistproc ctrl --working-directory /path/to/project restart "my-server-label"
 ```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -5,6 +5,117 @@ This page documents all persistproc commands and their usage. Most commands are 
 !!! info "What is a tool?"
     persistproc is primarily an MCP server, but all its tools are accessible to you on the command line. This page will discuss each tool in its command line form. The agent has access to the exact same functionality, just through a different mechanism for calling the tools.
 
+## `ctrl`
+
+**Unified process control** - the recommended way to manage processes with persistproc. This command provides a single interface for start, stop, and restart operations with consistent arguments and output format.
+
+<!-- persistproc ctrl --help -->
+```
+usage: persistproc ctrl [-h] [--port PORT] [--data-dir DATA_DIR] [-v] [-q]
+                        [--format {text,json}] [--working-directory WORKING_DIRECTORY]
+                        [--environment ENVIRONMENT] [--force] [--label LABEL]
+                        {start,stop,restart} TARGET [args ...]
+
+positional arguments:
+  {start,stop,restart}  The action to perform: start, stop, or restart
+  TARGET                The PID, label, command, or command to start (depending on action)
+  args                  Arguments to the command
+
+options:
+  -h, --help            show this help message and exit
+  --port PORT           Server port (default: 8947; env: $PERSISTPROC_PORT)
+  --data-dir DATA_DIR   Data directory (default:
+                        ~/Library/Application Support/persistproc;
+                        env: $PERSISTPROC_DATA_DIR)
+  -v, --verbose         Increase verbosity; you can use -vv for more
+  -q, --quiet           Decrease verbosity. Passing -q once will show only
+                        warnings and errors.
+  --format {text,json}  Output format (default: text; env:
+                        $PERSISTPROC_FORMAT)
+  --working-directory WORKING_DIRECTORY
+                        The working directory for the process (required for start, optional for stop/restart)
+  --environment ENVIRONMENT
+                        Environment variables as JSON string (start only)
+  --force               Force stop the process (stop only)
+  --label LABEL         Custom label for the process
+```
+
+**Examples**
+
+Start a new process:
+
+```bash
+> persistproc ctrl start npm run dev
+Started process with PID: 12345
+Action: start
+Label: npm run dev in /Users/user/myproject
+Stdout log: /Users/user/Library/Application Support/persistproc/logs/12345_stdout.log
+Stderr log: /Users/user/Library/Application Support/persistproc/logs/12345_stderr.log
+Combined log: /Users/user/Library/Application Support/persistproc/logs/12345_combined.log
+```
+
+Start with custom working directory and label:
+
+```bash
+> persistproc ctrl --working-directory /path/to/project --label "api-server" start python -m uvicorn app:main --host 0.0.0.0 --port 8000
+```
+
+Start with environment variables:
+
+```bash
+> persistproc ctrl --environment '{"DEBUG": "1", "PORT": "3000"}' start node server.js
+```
+
+Stop a process by PID:
+
+```bash
+> persistproc ctrl stop 12345
+Action: stop
+PID: 12345
+Previous exit code: 0
+Stdout log: /Users/user/Library/Application Support/persistproc/logs/12345_stdout.log
+Stderr log: /Users/user/Library/Application Support/persistproc/logs/12345_stderr.log
+Combined log: /Users/user/Library/Application Support/persistproc/logs/12345_combined.log
+```
+
+Stop a process by command:
+
+```bash
+> persistproc ctrl stop npm run dev
+> persistproc ctrl --working-directory /path/to/project stop npm run dev
+```
+
+Force stop a process:
+
+```bash
+> persistproc ctrl --force stop 12345
+```
+
+Restart a process:
+
+```bash
+> persistproc ctrl restart 12345
+Action: restart
+PID: 54321
+Previous exit code: 0
+Stdout log: /Users/user/Library/Application Support/persistproc/logs/54321_stdout.log
+Stderr log: /Users/user/Library/Application Support/persistproc/logs/54321_stderr.log
+Combined log: /Users/user/Library/Application Support/persistproc/logs/54321_combined.log
+
+> persistproc ctrl restart npm run dev
+> persistproc ctrl --working-directory /path/to/project restart "my-server-label"
+```
+
+!!! tip "Why use ctrl?"
+    The `ctrl` command provides several advantages over individual commands:
+    
+    - **Unified interface**: One command with consistent options for all operations
+    - **Enhanced output**: Always includes log paths in results for easy access
+    - **Better semantics**: Clear action-based syntax that's easy to understand
+    - **Future-proof**: New features will be added to ctrl first
+    
+    While the individual `start`, `stop`, and `restart` commands remain available for backwards compatibility, `ctrl` is recommended for new workflows.
+
 ## `serve`
 
 !!! note "Command-line only"

--- a/persistproc/cli.py
+++ b/persistproc/cli.py
@@ -229,6 +229,9 @@ def parse_cli(argv: list[str]) -> tuple[CLIAction, CLIMetadata]:
         special_aliases = []
         if snake == "list":
             special_aliases.append("ls")
+        elif snake == "ctrl":
+            # No direct aliases for ctrl - the backwards compatibility is handled differently
+            pass
 
         # Create **one** sub-parser (canonical) and register alias via `aliases=` so it
         # does not appear twice in `--help` output.

--- a/persistproc/cli.py
+++ b/persistproc/cli.py
@@ -229,9 +229,6 @@ def parse_cli(argv: list[str]) -> tuple[CLIAction, CLIMetadata]:
         special_aliases = []
         if snake == "list":
             special_aliases.append("ls")
-        elif snake == "ctrl":
-            # No direct aliases for ctrl - the backwards compatibility is handled differently
-            pass
 
         # Create **one** sub-parser (canonical) and register alias via `aliases=` so it
         # does not appear twice in `--help` output.
@@ -251,6 +248,69 @@ def parse_cli(argv: list[str]) -> tuple[CLIAction, CLIMetadata]:
         tools_by_name[kebab] = tool
         for alias in special_aliases:
             tools_by_name[alias] = tool
+
+        # Create separate backwards compatibility subparsers for start/stop/restart
+        if snake == "ctrl":
+            for old_cmd in ["start", "stop", "restart"]:
+                if old_cmd not in subparsers.choices:
+                    p_compat = subparsers.add_parser(
+                        old_cmd,
+                        help=f"{old_cmd.title()} process (alias for 'ctrl {old_cmd}')",
+                        parents=[common_parser],
+                    )
+
+                    # Configure arguments to match old format
+                    if old_cmd == "start":
+                        p_compat.add_argument(
+                            "--working-directory",
+                            help="The working directory for the process",
+                        )
+                        p_compat.add_argument(
+                            "--environment",
+                            type=str,
+                            help="Environment variables as JSON string",
+                        )
+                        p_compat.add_argument(
+                            "--label",
+                            type=str,
+                            help="Custom label for the process",
+                        )
+                        p_compat.add_argument(
+                            "command_",
+                            metavar="COMMAND",
+                            help="The command to start",
+                        )
+                        p_compat.add_argument(
+                            "args", nargs="*", help="Arguments to the command"
+                        )
+                    else:  # stop, restart
+                        p_compat.add_argument(
+                            "--working-directory",
+                            help="The working directory for the process",
+                        )
+                        p_compat.add_argument(
+                            "target",
+                            metavar="TARGET",
+                            help="The PID, label, or command to stop/restart",
+                        )
+                        p_compat.add_argument(
+                            "args", nargs="*", help="Arguments to the command"
+                        )
+                        if old_cmd == "stop":
+                            p_compat.add_argument(
+                                "--force",
+                                action="store_true",
+                                help="Force stop the process",
+                            )
+                        elif old_cmd == "restart":
+                            p_compat.add_argument(
+                                "--label",
+                                type=str,
+                                help="Custom label for the process",
+                            )
+
+                    # Map to ctrl tool for execution
+                    tools_by_name[old_cmd] = tool
 
     # Argument parsing
     if not argv:

--- a/persistproc/process_manager.py
+++ b/persistproc/process_manager.py
@@ -496,7 +496,7 @@ class ProcessManager:  # noqa: D101
             return ProcessControlResult(
                 action=action,
                 pid=target_pid,
-                previous_exit_code=stop_res.exit_code,
+                exit_code=stop_res.exit_code,
                 log_stdout=log_stdout,
                 log_stderr=log_stderr,
                 log_combined=log_combined,
@@ -514,11 +514,11 @@ class ProcessManager:  # noqa: D101
                 Path(working_directory) if working_directory else None,
             )
 
-            previous_exit_code = None
+            exit_code = None
             if pid_to_restart is not None:
                 original_entry = self._storage.get_process_snapshot(pid_to_restart)
                 if original_entry is not None and hasattr(original_entry, "exit_code"):
-                    previous_exit_code = original_entry.exit_code
+                    exit_code = original_entry.exit_code
 
             restart_res = self.restart(
                 pid=pid,
@@ -549,7 +549,7 @@ class ProcessManager:  # noqa: D101
             return ProcessControlResult(
                 action=action,
                 pid=restart_res.pid,
-                previous_exit_code=previous_exit_code,
+                exit_code=exit_code,
                 log_stdout=log_stdout,
                 log_stderr=log_stderr,
                 log_combined=log_combined,

--- a/persistproc/process_types.py
+++ b/persistproc/process_types.py
@@ -89,7 +89,7 @@ class ProcessControlResult:
 
     action: str  # "start", "stop", or "restart"
     pid: int | None = None  # new PID for start/restart
-    previous_exit_code: int | None = None  # exit code of stopped process for restart
+    exit_code: int | None = None  # exit code of stopped process for stop/restart
     log_stdout: str | None = None  # always included when available
     log_stderr: str | None = None  # always included when available
     log_combined: str | None = None  # always included when available

--- a/persistproc/process_types.py
+++ b/persistproc/process_types.py
@@ -11,6 +11,7 @@ __all__ = [
     "ListProcessesResult",
     "ProcessOutputResult",
     "RestartProcessResult",
+    "ProcessControlResult",
     "StreamEnum",
 ]
 
@@ -79,6 +80,20 @@ class RestartProcessResult:
     """
 
     pid: int | None = None
+    error: str | None = None
+
+
+@dataclass
+class ProcessControlResult:
+    """Unified result for start, stop, and restart operations."""
+
+    action: str  # "start", "stop", or "restart"
+    pid: int | None = None  # new PID for start/restart
+    previous_exit_code: int | None = None  # exit code of stopped process for restart
+    log_stdout: str | None = None  # always included when available
+    log_stderr: str | None = None  # always included when available
+    log_combined: str | None = None  # always included when available
+    label: str | None = None  # always included when available
     error: str | None = None
 
 

--- a/persistproc/run.py
+++ b/persistproc/run.py
@@ -187,18 +187,21 @@ async def _start_or_get_process_via_mcp(
                 )
 
                 if existing and fresh:
-                    await client.call_tool("stop", {"pid": existing["pid"]})
+                    await client.call_tool(
+                        "ctrl", {"action": "stop", "pid": existing["pid"]}
+                    )
                     existing = None
 
                 if existing is None:
                     start_params = {
-                        "command": command_str,
+                        "action": "start",
+                        "command_or_label": command_str,
                         "working_directory": working_directory,
                         "environment": dict(os.environ),
                     }
                     if label is not None:
                         start_params["label"] = label
-                    start_res = await client.call_tool("start", start_params)
+                    start_res = await client.call_tool("ctrl", start_params)
                     start_info = json.loads(start_res[0].text)
                     if start_info["error"]:
                         CLI_LOGGER.error(start_info["error"])
@@ -235,7 +238,7 @@ async def _stop_process_via_mcp(port: int, pid: int) -> None:  # noqa: D401 – 
     """Best-effort attempt to stop *pid* via MCP."""
     try:
         async with make_client(port) as client:
-            await client.call_tool("stop", {"pid": pid})
+            await client.call_tool("ctrl", {"action": "stop", "pid": pid})
     except Exception as exc:  # pragma: no cover – soft failure
         logger.warning("Failed to stop process %s via MCP: %s", pid, exc)
 

--- a/persistproc/tools.py
+++ b/persistproc/tools.py
@@ -21,6 +21,9 @@ from .process_types import (
 
 import logging
 
+# WARNING: run.py depends on details of this file in ways that the linter and
+# type checker cannot detect! Specifically tool names, parameters, and return types.
+
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,6 +147,254 @@ def test_parse_cli_quiet_flags(mock_setup_logging):
     mock_setup_logging.assert_called_with(-2, get_default_data_dir())
 
 
+# ========================================================================
+# Comprehensive tests for the ctrl unified command
+# ========================================================================
+
+
+def test_parse_cli_ctrl_start_basic(mock_setup_logging):
+    """Test `persistproc ctrl start command`."""
+    action, metadata = parse_cli(["ctrl", "start", "sleep", "10"])
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "start"
+    assert action.args.target == "sleep"
+    assert action.args.args == ["10"]
+    assert action.args.working_directory is None  # Will default to cwd in tool
+
+
+def test_parse_cli_ctrl_start_with_working_directory(mock_setup_logging, tmp_path):
+    """Test `persistproc ctrl --working-directory /path start command`."""
+    action, metadata = parse_cli(
+        ["ctrl", "--working-directory", str(tmp_path), "start", "npm", "run", "dev"]
+    )
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "start"
+    assert action.args.target == "npm"
+    assert action.args.args == ["run", "dev"]
+    assert action.args.working_directory == str(tmp_path)
+
+
+def test_parse_cli_ctrl_start_with_label(mock_setup_logging):
+    """Test `persistproc ctrl --label mylabel start command`."""
+    action, metadata = parse_cli(
+        ["ctrl", "--label", "myserver", "start", "python -m http.server"]
+    )
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "start"
+    assert action.args.target == "python -m http.server"
+    assert action.args.args == []
+    assert action.args.label == "myserver"
+
+
+def test_parse_cli_ctrl_start_with_environment(mock_setup_logging):
+    """Test `persistproc ctrl --environment '{}' start command`."""
+    action, metadata = parse_cli(
+        ["ctrl", "--environment", '{"DEBUG": "1"}', "start", "python script.py"]
+    )
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "start"
+    assert action.args.target == "python script.py"
+    assert action.args.args == []
+    assert action.args.environment == '{"DEBUG": "1"}'
+
+
+def test_parse_cli_ctrl_stop_by_pid(mock_setup_logging):
+    """Test `persistproc ctrl stop 123`."""
+    action, metadata = parse_cli(["ctrl", "stop", "123"])
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "stop"
+    assert action.args.target == "123"
+    assert action.args.args == []
+
+
+def test_parse_cli_ctrl_stop_by_command(mock_setup_logging):
+    """Test `persistproc ctrl stop npm run dev`."""
+    action, metadata = parse_cli(["ctrl", "stop", "npm", "run", "dev"])
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "stop"
+    assert action.args.target == "npm"
+    assert action.args.args == ["run", "dev"]
+
+
+def test_parse_cli_ctrl_stop_with_force(mock_setup_logging):
+    """Test `persistproc ctrl --force stop 123`."""
+    action, metadata = parse_cli(["ctrl", "--force", "stop", "123"])
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "stop"
+    assert action.args.target == "123"
+    assert action.args.force is True
+
+
+def test_parse_cli_ctrl_stop_with_working_directory(mock_setup_logging, tmp_path):
+    """Test `persistproc ctrl --working-directory /path stop command`."""
+    action, metadata = parse_cli(
+        ["ctrl", "--working-directory", str(tmp_path), "stop", "npm", "run", "dev"]
+    )
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "stop"
+    assert action.args.target == "npm"
+    assert action.args.args == ["run", "dev"]
+    assert action.args.working_directory == str(tmp_path)
+
+
+def test_parse_cli_ctrl_restart_by_pid(mock_setup_logging):
+    """Test `persistproc ctrl restart 123`."""
+    action, metadata = parse_cli(["ctrl", "restart", "123"])
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "restart"
+    assert action.args.target == "123"
+    assert action.args.args == []
+
+
+def test_parse_cli_ctrl_restart_by_command(mock_setup_logging):
+    """Test `persistproc ctrl restart npm run dev`."""
+    action, metadata = parse_cli(["ctrl", "restart", "npm", "run", "dev"])
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "restart"
+    assert action.args.target == "npm"
+    assert action.args.args == ["run", "dev"]
+
+
+def test_parse_cli_ctrl_restart_with_label(mock_setup_logging):
+    """Test `persistproc ctrl --label mylabel restart command`."""
+    action, metadata = parse_cli(["ctrl", "--label", "mylabel", "restart", "mycommand"])
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "restart"
+    assert action.args.target == "mycommand"
+    assert action.args.label == "mylabel"
+
+
+def test_parse_cli_ctrl_restart_with_working_directory(mock_setup_logging, tmp_path):
+    """Test `persistproc ctrl --working-directory /path restart command`."""
+    action, metadata = parse_cli(
+        ["ctrl", "--working-directory", str(tmp_path), "restart", "npm", "run", "dev"]
+    )
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "restart"
+    assert action.args.target == "npm"
+    assert action.args.args == ["run", "dev"]
+    assert action.args.working_directory == str(tmp_path)
+
+
+def test_parse_cli_ctrl_no_action_should_fail(mock_setup_logging):
+    """Test that `persistproc ctrl` without action fails."""
+    with pytest.raises(SystemExit):
+        parse_cli(["ctrl"])
+
+
+def test_parse_cli_ctrl_invalid_action_should_fail(mock_setup_logging):
+    """Test that `persistproc ctrl invalid` fails."""
+    with pytest.raises(SystemExit):
+        parse_cli(["ctrl", "invalid"])
+
+
+def test_parse_cli_ctrl_start_no_target_should_fail(mock_setup_logging):
+    """Test that `persistproc ctrl start` without target fails."""
+    with pytest.raises(SystemExit):
+        parse_cli(["ctrl", "start"])
+
+
+def test_parse_cli_ctrl_stop_no_target_should_fail(mock_setup_logging):
+    """Test that `persistproc ctrl stop` without target fails."""
+    with pytest.raises(SystemExit):
+        parse_cli(["ctrl", "stop"])
+
+
+def test_parse_cli_ctrl_restart_no_target_should_fail(mock_setup_logging):
+    """Test that `persistproc ctrl restart` without target fails."""
+    with pytest.raises(SystemExit):
+        parse_cli(["ctrl", "restart"])
+
+
+# ========================================================================
+# Tests for backwards compatibility - existing commands should still work
+# ========================================================================
+
+
+def test_parse_cli_backwards_compatibility_start(mock_setup_logging):
+    """Test that `persistproc start` still works."""
+    action, metadata = parse_cli(["start", "sleep", "10"])
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "start"
+    assert action.args.command_ == "sleep"
+    assert action.args.args == ["10"]
+
+
+def test_parse_cli_backwards_compatibility_stop(mock_setup_logging):
+    """Test that `persistproc stop` still works."""
+    action, metadata = parse_cli(["stop", "123"])
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "stop"
+    assert action.args.target == "123"
+
+
+def test_parse_cli_backwards_compatibility_restart(mock_setup_logging):
+    """Test that `persistproc restart` still works."""
+    action, metadata = parse_cli(["restart", "123"])
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "restart"
+    assert action.args.target == "123"
+
+
+# ========================================================================
+# Test edge cases and complex scenarios
+# ========================================================================
+
+
+def test_parse_cli_ctrl_with_complex_command(mock_setup_logging):
+    """Test ctrl with complex multi-word commands."""
+    action, metadata = parse_cli(
+        ["ctrl", "start", "python -u -m uvicorn app:main --host 0.0.0.0 --port 8000"]
+    )
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "start"
+    assert (
+        action.args.target == "python -u -m uvicorn app:main --host 0.0.0.0 --port 8000"
+    )
+    assert action.args.args == []
+
+
+def test_parse_cli_ctrl_with_all_options(mock_setup_logging, tmp_path):
+    """Test ctrl start with all possible options."""
+    action, metadata = parse_cli(
+        [
+            "ctrl",
+            "--working-directory",
+            str(tmp_path),
+            "--environment",
+            '{"DEBUG": "1"}',
+            "--label",
+            "myprocess",
+            "--format",
+            "json",
+            "start",
+            "python script.py",
+        ]
+    )
+    assert isinstance(action, ToolAction)
+    assert action.tool.name == "ctrl"
+    assert action.args.action == "start"
+    assert action.args.target == "python script.py"
+    assert action.args.args == []
+    assert action.args.working_directory == str(tmp_path)
+    assert action.args.environment == '{"DEBUG": "1"}'
+    assert action.args.label == "myprocess"
+    assert action.format == "json"
+
+
 def test_root_help_displays_subcommands(mock_setup_logging):
     """`persistproc --help` lists available sub-commands (serve, run, etc.)."""
     # Test that help flag triggers SystemExit (which argparse does for help)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,7 +103,7 @@ def test_parse_cli_restart_process_by_pid(mock_setup_logging):
     """Test `persistproc restart 123`."""
     action, metadata = parse_cli(["restart", "123"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "restart"
+    assert action.tool.name == "ctrl"
     assert action.args.target == "123"
     assert not action.args.args
 
@@ -112,7 +112,7 @@ def test_parse_cli_restart_process_by_command(mock_setup_logging):
     """Test `persistproc restart sleep 10`."""
     action, metadata = parse_cli(["restart", "sleep", "10"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "restart"
+    assert action.tool.name == "ctrl"
     assert action.args.target == "sleep"
     assert action.args.args == ["10"]
 
@@ -123,7 +123,7 @@ def test_parse_cli_restart_process_by_command_and_cwd(mock_setup_logging, tmp_pa
         ["restart", "--working-directory", str(tmp_path), "sleep", "10"]
     )
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "restart"
+    assert action.tool.name == "ctrl"
     assert action.args.target == "sleep"
     assert action.args.args == ["10"]
     assert action.args.working_directory == str(tmp_path)
@@ -319,36 +319,6 @@ def test_parse_cli_ctrl_restart_no_target_should_fail(mock_setup_logging):
 
 
 # ========================================================================
-# Tests for backwards compatibility - existing commands should still work
-# ========================================================================
-
-
-def test_parse_cli_backwards_compatibility_start(mock_setup_logging):
-    """Test that `persistproc start` still works."""
-    action, metadata = parse_cli(["start", "sleep", "10"])
-    assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
-    assert action.args.command_ == "sleep"
-    assert action.args.args == ["10"]
-
-
-def test_parse_cli_backwards_compatibility_stop(mock_setup_logging):
-    """Test that `persistproc stop` still works."""
-    action, metadata = parse_cli(["stop", "123"])
-    assert isinstance(action, ToolAction)
-    assert action.tool.name == "stop"
-    assert action.args.target == "123"
-
-
-def test_parse_cli_backwards_compatibility_restart(mock_setup_logging):
-    """Test that `persistproc restart` still works."""
-    action, metadata = parse_cli(["restart", "123"])
-    assert isinstance(action, ToolAction)
-    assert action.tool.name == "restart"
-    assert action.args.target == "123"
-
-
-# ========================================================================
 # Test edge cases and complex scenarios
 # ========================================================================
 
@@ -409,7 +379,7 @@ def test_parse_cli_stop_process_by_pid(mock_setup_logging):
     """Test `persistproc stop 123`."""
     action, metadata = parse_cli(["stop", "123"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "stop"
+    assert action.tool.name == "ctrl"
     assert action.args.target == "123"
     assert not action.args.args
 
@@ -418,7 +388,7 @@ def test_parse_cli_stop_process_by_command(mock_setup_logging):
     """Test `persistproc stop sleep 10`."""
     action, metadata = parse_cli(["stop", "sleep", "10"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "stop"
+    assert action.tool.name == "ctrl"
     assert action.args.target == "sleep"
     assert action.args.args == ["10"]
 
@@ -427,7 +397,7 @@ def test_parse_cli_start_with_label(mock_setup_logging):
     """Test `persistproc start echo hello --label my-label`."""
     action, metadata = parse_cli(["start", "echo", "hello", "--label", "my-label"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "echo"
     assert action.args.args == ["hello"]
     assert action.args.label == "my-label"
@@ -437,7 +407,7 @@ def test_parse_cli_start_without_label(mock_setup_logging):
     """Test `persistproc start echo hello` (no label)."""
     action, metadata = parse_cli(["start", "echo", "hello"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "echo"
     assert action.args.args == ["hello"]
     assert getattr(action.args, "label", None) is None
@@ -523,7 +493,7 @@ def test_parse_cli_start_with_double_dash_separator(mock_setup_logging):
     """Test `persistproc start python -- script.py arg1 arg2`."""
     action, metadata = parse_cli(["start", "python", "--", "script.py", "arg1", "arg2"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "python"
     assert action.args.args == ["script.py", "arg1", "arg2"]
 
@@ -534,7 +504,7 @@ def test_parse_cli_start_with_label_and_separator(mock_setup_logging):
         ["start", "--label", "backend", "python", "--", "-m", "uvicorn", "app:main"]
     )
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "python"
     assert action.args.args == ["-m", "uvicorn", "app:main"]
     assert action.args.label == "backend"
@@ -555,7 +525,7 @@ def test_parse_cli_start_with_working_dir_and_separator(mock_setup_logging):
         ]
     )
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "node"
     assert action.args.args == ["server.js", "--port", "3000"]
     assert action.args.working_directory == "/app"
@@ -565,7 +535,7 @@ def test_parse_cli_start_no_separator_simple(mock_setup_logging):
     """Test `persistproc start echo` - simple command without args."""
     action, metadata = parse_cli(["start", "echo"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "echo"
     assert action.args.args == []
 
@@ -596,7 +566,7 @@ def test_parse_cli_start_command_with_equals_in_args(mock_setup_logging):
         ["start", "python", "--", "script.py", "--config=prod.ini"]
     )
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "python"
     assert action.args.args == ["script.py", "--config=prod.ini"]
 
@@ -640,7 +610,7 @@ def test_parse_cli_start_invalid_flag_without_separator(mock_setup_logging):
     # This parses but probably not what user intended
     action, metadata = parse_cli(["start", "npm", "run", "dev"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "npm"
     assert action.args.args == [
         "run",
@@ -677,7 +647,7 @@ def test_parse_cli_start_with_port_ambiguity(mock_setup_logging):
     # --port is consumed by the global parser, not passed to python!
     action, metadata = parse_cli(["start", "python", "app.py", "--port", "8080"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "python"
     assert action.args.args == ["app.py"]  # --port 8080 was consumed!
     assert action.args.port == 8080  # --port went to persistproc
@@ -687,7 +657,7 @@ def test_parse_cli_start_correct_port_usage(mock_setup_logging):
     """Test correct: `persistproc start python -- app.py --port 8080`."""
     action, metadata = parse_cli(["start", "python", "--", "app.py", "--port", "8080"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "python"
     assert action.args.args == ["app.py", "--port", "8080"]
 
@@ -739,7 +709,7 @@ def test_parse_cli_stop_with_double_dash_separator(mock_setup_logging):
     """Test `persistproc stop python -- -m http.server`."""
     action, metadata = parse_cli(["stop", "python", "--", "-m", "http.server"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "stop"
+    assert action.tool.name == "ctrl"
     assert action.args.target == "python"
     assert action.args.args == ["-m", "http.server"]
 
@@ -755,7 +725,7 @@ def test_parse_cli_restart_with_double_dash_separator(mock_setup_logging):
     """Test `persistproc restart node -- --inspect server.js`."""
     action, metadata = parse_cli(["restart", "node", "--", "--inspect", "server.js"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "restart"
+    assert action.tool.name == "ctrl"
     assert action.args.target == "node"
     assert action.args.args == ["--inspect", "server.js"]
 
@@ -766,7 +736,7 @@ def test_parse_cli_restart_with_working_dir_and_separator(mock_setup_logging):
         ["restart", "--working-directory", "/app", "python", "--", "-m", "myapp"]
     )
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "restart"
+    assert action.tool.name == "ctrl"
     assert action.args.target == "python"
     assert action.args.args == ["-m", "myapp"]
     assert action.args.working_directory == "/app"
@@ -776,7 +746,7 @@ def test_parse_cli_stop_by_label(mock_setup_logging):
     """Test `persistproc stop my-app-label`."""
     action, metadata = parse_cli(["stop", "my-app-label"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "stop"
+    assert action.tool.name == "ctrl"
     assert action.args.target == "my-app-label"
     assert action.args.args == []
 
@@ -785,7 +755,7 @@ def test_parse_cli_restart_by_label(mock_setup_logging):
     """Test `persistproc restart my-app-label`."""
     action, metadata = parse_cli(["restart", "my-app-label"])
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "restart"
+    assert action.tool.name == "ctrl"
     assert action.args.target == "my-app-label"
     assert action.args.args == []
 
@@ -849,7 +819,7 @@ def test_parse_cli_start_mixed_flags_and_args(mock_setup_logging):
         ]
     )
     assert isinstance(action, ToolAction)
-    assert action.tool.name == "start"
+    assert action.tool.name == "ctrl"
     assert action.args.command_ == "python"
     assert action.args.args == ["-m", "uvicorn", "app:main", "--port", "8000"]
     assert action.args.label == "web"


### PR DESCRIPTION
LLMs perform worse with too many tools, so MCP servers in general should endeavor to limit the number of tools they expose.